### PR TITLE
Check if db is available, not just when setup is run

### DIFF
--- a/rootfs/usr/local/bin/run.sh
+++ b/rootfs/usr/local/bin/run.sh
@@ -15,6 +15,15 @@ if [ "$PHP_HARDENING" == "true" ] && [ ! -f /usr/local/etc/php/conf.d/snuffleupa
     cp /usr/local/etc/php/snuffleupagus/* /usr/local/etc/php/conf.d
 fi
 
+# Check if database is available
+if [ -n "${DB_TYPE}" ] && [ "${DB_TYPE}" != "sqlite3" ]; then
+  until nc -z "${DB_HOST:-nextcloud-db}" "${DB_PORT:-3306}"
+  do
+    echo "waiting for the database container..."
+    sleep 1
+  done
+fi
+
 # If new install, run setup
 if [ ! -f /nextcloud/config/config.php ]; then
     touch /nextcloud/config/CAN_INSTALL

--- a/rootfs/usr/local/bin/setup.sh
+++ b/rootfs/usr/local/bin/setup.sh
@@ -55,14 +55,6 @@ cat >> /nextcloud/config/autoconfig.php <<EOF;
 ?>
 EOF
 
-if [ ${DB_TYPE} != "sqlite3" ]; then
-  until nc -z "${DB_HOST:-nextcloud-db}" "${DB_PORT:-3306}"
-  do
-    echo "waiting for the database container..."
-    sleep 1
-  done
-fi
-
 echo "Starting automatic configuration..."
 # Execute setup
 (cd /nextcloud; php index.php &>/dev/null)


### PR DESCRIPTION
Checking for a available database when installing is fine, but running occ upgrade without a db available is also a problem. This checks for db availability in every case.