### PR TITLE
Remove legacy header X-Download-Options

### DIFF
--- a/rootfs/etc/nginx/conf.d/default.conf
+++ b/rootfs/etc/nginx/conf.d/default.conf
@@ -18,7 +18,6 @@ server {
 
         add_header Referrer-Policy "no-referrer" always;
         add_header X-Content-Type-Options "nosniff" always;
-        add_header X-Download-Options "noopen" always;
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Permitted-Cross-Domain-Policies "none" always;
         add_header X-Robots-Tag "noindex, nofollow" always;


### PR DESCRIPTION
While digging into #60 I stumbled upon this

The header has been removed from the nextcloud/server code: nextcloud/server@ea0e45d

See https://github.com/nextcloud/documentation/commit/e543bec9ba0d9768ef64b50e4ce9a97081cf4d5a