### PR TITLE
Fix mp4 in reverse proxy

### DIFF
--- a/rootfs/etc/nginx/conf.d/default.conf
+++ b/rootfs/etc/nginx/conf.d/default.conf
@@ -78,7 +78,7 @@ server {
             access_log off;
         }
 
-        location ~ \.(?:png|html|ttf|ico|jpg|jpeg|bcmap)$ {
+        location ~ \.(?:png|html|ttf|ico|jpg|jpeg|bcmap|mp4|webm)$ {
             try_files $uri /index.php$uri$is_args$args;
             access_log off;
         }


### PR DESCRIPTION
Add missing mp4 and webm formats according to documentation
Fixes issue #93 
